### PR TITLE
fix(lint): resolve unicorn lint violations ahead of eslint-config bump

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ export interface ConfigInterface {
   }
 }
 
-export class Configuration extends ConfigFramework<ConfigInterface> {
+export class Config extends ConfigFramework<ConfigInterface> {
   protected validates(): Record<string, (config: ConfigInterface) => boolean> {
     return {
       'discord is required': (config) => !!config.discord,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -10,7 +10,7 @@ import {
   SlashCommandSubcommandGroupBuilder,
 } from 'discord.js'
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { BaseDiscordEvent } from './events'
 import { GuildEventCreated } from './events/guild-event-created'
 import { GuildEventStarted } from './events/guild-event-started'
@@ -19,7 +19,7 @@ import { RegisterCommand } from './commands/register'
 import { UnregisterCommand } from './commands/unregister'
 
 export class Discord {
-  private config: Configuration
+  private config: Config
   public readonly client: Client
   public readonly rest: REST
   private onInteractionCreateFunction: (interaction: BaseInteraction) => void
@@ -29,7 +29,7 @@ export class Discord {
     new UnregisterCommand(),
   ]
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     const logger = Logger.configure('Discord.constructor')
     this.client = new Client({
       intents: [
@@ -39,14 +39,22 @@ export class Discord {
       partials: [Partials.GuildScheduledEvent],
     })
     this.client.on('ready', () => {
-      this.onReady().catch((error: unknown) => {
-        logger.error('❌ Failed to onReady', error as Error)
-      })
+      ;(async () => {
+        try {
+          await this.onReady()
+        } catch (error: unknown) {
+          logger.error('❌ Failed to onReady', error as Error)
+        }
+      })()
     })
     this.onInteractionCreateFunction = (interaction) => {
-      this.onInteractionCreate(interaction).catch((error: unknown) => {
-        logger.error('❌ Failed to onInteractionCreate', error as Error)
-      })
+      ;(async () => {
+        try {
+          await this.onInteractionCreate(interaction)
+        } catch (error: unknown) {
+          logger.error('❌ Failed to onInteractionCreate', error as Error)
+        }
+      })()
     }
     this.client.on('interactionCreate', this.onInteractionCreateFunction)
 
@@ -61,10 +69,15 @@ export class Discord {
     this.rest = new REST().setToken(config.get('discord').token)
     this.config = config
 
-    this.client.login(config.get('discord').token).catch((error: unknown) => {
-      const logger = Logger.configure('Discord.constructor')
-      logger.error('❌ Failed to login', error as Error)
-    })
+    const client = this.client
+    ;(async () => {
+      try {
+        await client.login(config.get('discord').token)
+      } catch (error: unknown) {
+        const logger = Logger.configure('Discord.constructor')
+        logger.error('❌ Failed to login', error as Error)
+      }
+    })()
   }
 
   public getClient() {
@@ -92,10 +105,13 @@ export class Discord {
         logger.info('🔄 Re-registering interactionCreate handler')
         this.client.off('interactionCreate', this.onInteractionCreateFunction)
         this.client.on('interactionCreate', this.onInteractionCreateFunction)
-
-        this.updateAllGuildCommands().catch((error: unknown) => {
-          logger.error('❌ Failed to update commands', error as Error)
-        })
+        ;(async () => {
+          try {
+            await this.updateAllGuildCommands()
+          } catch (error: unknown) {
+            logger.error('❌ Failed to update commands', error as Error)
+          }
+        })()
       },
       1000 * 60 * 60
     )

--- a/src/events/guild-event-created.ts
+++ b/src/events/guild-event-created.ts
@@ -1,7 +1,7 @@
 import { GuildScheduledEvent, MessageFlags } from 'discord.js'
 import { BaseDiscordEvent } from '.'
 import { EventNotifyServer } from '@/server'
-import { Utils } from '@/utils'
+import { Utilities } from '@/utilities'
 
 /**
  * イベントが作成されたとき
@@ -26,7 +26,7 @@ export class GuildEventCreated extends BaseDiscordEvent<'guildScheduledEventCrea
     }
 
     const embed =
-      Utils.getEventEmbed(event).setTitle(`:new:イベントが追加されました！`)
+      Utilities.getEventEmbed(event).setTitle(`:new:イベントが追加されました！`)
     await channel.send({
       embeds: [embed],
       flags: MessageFlags.SuppressNotifications,

--- a/src/events/guild-event-started.ts
+++ b/src/events/guild-event-started.ts
@@ -1,7 +1,7 @@
 import { GuildScheduledEvent, MessageFlags } from 'discord.js'
 import { BaseDiscordEvent } from '.'
 import { EventNotifyServer } from '@/server'
-import { Utils } from '@/utils'
+import { Utilities } from '@/utilities'
 
 /**
  * イベントが開始されたとき
@@ -35,7 +35,9 @@ export class GuildEventStarted extends BaseDiscordEvent<'guildScheduledEventUpda
       .join(' ')
 
     const embed =
-      Utils.getEventEmbed(newEvent).setTitle(`:tada:イベントが始まりました！`)
+      Utilities.getEventEmbed(newEvent).setTitle(
+        `:tada:イベントが始まりました！`
+      )
     await channel.send({
       content: mentions,
       embeds: [embed],

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -12,9 +12,13 @@ export abstract class BaseDiscordEvent<T extends keyof ClientEvents> {
 
   register(): void {
     this.discord.client.on(this.eventName, (...eventArguments) => {
-      this.execute(...eventArguments).catch((error: unknown) => {
-        console.error(`❌ Failed to execute ${this.eventName}`, error)
-      })
+      ;(async () => {
+        try {
+          await this.execute(...eventArguments)
+        } catch (error: unknown) {
+          console.error(`❌ Failed to execute ${this.eventName}`, error)
+        }
+      })()
     })
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { Discord } from './discord'
 
 function main() {
   const logger = Logger.configure('main')
-  const config = new Configuration('data/config.json')
+  const config = new Config('data/config.json')
   config.load()
   if (!config.validate()) {
     logger.error('❌ Configuration is invalid')
@@ -18,15 +18,15 @@ function main() {
   const discord = new Discord(config)
   process.once('SIGINT', () => {
     logger.info('👋 SIGINT signal received.')
-    discord
-      .close()
-      .then(() => {
+    ;(async () => {
+      try {
+        await discord.close()
         process.exit(0)
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         logger.error('❌ Failed to close Discord client', error as Error)
         process.exit(1)
-      })
+      }
+    })()
   })
 }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,30 +1,24 @@
 import { EmbedBuilder, GuildScheduledEvent } from 'discord.js'
 
-export const Utils = {
+export const Utilities = {
   formatDate(date: Date, format: string): string {
-    format = format.replaceAll('yyyy', date.getFullYear().toString())
-    format = format.replaceAll(
-      'MM',
+    format = format.replaceAll('yyyy', () => date.getFullYear().toString())
+    format = format.replaceAll('MM', () =>
       ('0' + (date.getMonth() + 1).toString()).slice(-2)
     )
-    format = format.replaceAll(
-      'dd',
+    format = format.replaceAll('dd', () =>
       ('0' + date.getDate().toString()).slice(-2)
     )
-    format = format.replaceAll(
-      'HH',
+    format = format.replaceAll('HH', () =>
       ('0' + date.getHours().toString()).slice(-2)
     )
-    format = format.replaceAll(
-      'mm',
+    format = format.replaceAll('mm', () =>
       ('0' + date.getMinutes().toString()).slice(-2)
     )
-    format = format.replaceAll(
-      'ss',
+    format = format.replaceAll('ss', () =>
       ('0' + date.getSeconds().toString()).slice(-2)
     )
-    format = format.replaceAll(
-      'SSS',
+    format = format.replaceAll('SSS', () =>
       ('00' + date.getMilliseconds().toString()).slice(-3)
     )
     return format
@@ -40,13 +34,19 @@ export const Utils = {
     if (event.scheduledStartAt) {
       embed.addFields({
         name: 'イベント開始日時',
-        value: Utils.formatDate(event.scheduledStartAt, 'yyyy/MM/dd HH:mm:ss'),
+        value: Utilities.formatDate(
+          event.scheduledStartAt,
+          'yyyy/MM/dd HH:mm:ss'
+        ),
       })
     }
     if (event.scheduledEndAt) {
       embed.addFields({
         name: 'イベント終了日時',
-        value: Utils.formatDate(event.scheduledEndAt, 'yyyy/MM/dd HH:mm:ss'),
+        value: Utilities.formatDate(
+          event.scheduledEndAt,
+          'yyyy/MM/dd HH:mm:ss'
+        ),
       })
     }
     if (event.description) {


### PR DESCRIPTION
## Background

Renovate PR #2426 bumps `@book000/eslint-config` 1.15.4 -> 1.15.44, which pulls in a newer `eslint-plugin-unicorn` (v66 -> v71.1) that flags 19 pre-existing style issues, failing `lint:eslint` in Node CI once that bump lands.

## Changes

- `unicorn/name-replacements`: `Configuration` -> `Config` (config.ts/discord.ts/main.ts), `Utils`/`utils.ts` -> `Utilities`/`utilities.ts`
- `unicorn/no-unsafe-string-replacement`: pass a replacer function to `replaceAll()` instead of a non-literal replacement string (utilities.ts's `formatDate`)
- `unicorn/prefer-await`: replace `.then()`/`.catch()` promise chaining with `try`/`await`/`catch` (wrapped in an async IIFE where the surrounding callback must stay non-async/void-returning, e.g. `EventEmitter` listeners, to satisfy `@typescript-eslint/no-misused-promises`)

No behavior change. Verified locally with both the current `@book000/eslint-config@1.15.4` and the target `1.15.44`: `pnpm run lint` (prettier + eslint + tsc) passes clean on both.