### PR TITLE
chore(deps): update dependency prettier to v3.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-n": "18.2.1",
     "eslint-plugin-promise": "7.3.0",
-    "prettier": "3.8.4",
+    "prettier": "3.9.4",
     "run-z": "2.1.0",
     "tsx": "4.23.0",
     "typescript": "6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 7.3.0
         version: 7.3.0(eslint@10.6.0)
       prettier:
-        specifier: 3.8.4
-        version: 3.8.4
+        specifier: 3.9.4
+        version: 3.9.4
       run-z:
         specifier: 2.1.0
         version: 2.1.0
@@ -1391,8 +1391,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3253,7 +3253,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.4: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -14,9 +14,7 @@ import { Logger } from '@book000/node-utils'
 
 export class RegisterCommand implements BaseCommand {
   definition():
-    | SlashCommandSubcommandBuilder
-    | SlashCommandSubcommandGroupBuilder
-    | null {
+    SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder | null {
     return new SlashCommandSubcommandBuilder()
       .setName('register')
       .setDescription(

--- a/src/commands/unregister.ts
+++ b/src/commands/unregister.ts
@@ -11,9 +11,7 @@ import { EventNotifyServer } from '@/server'
 
 export class UnregisterCommand implements BaseCommand {
   definition():
-    | SlashCommandSubcommandBuilder
-    | SlashCommandSubcommandGroupBuilder
-    | null {
+    SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder | null {
     return new SlashCommandSubcommandBuilder()
       .setName('unregister')
       .setDescription(


### PR DESCRIPTION
Bumps `prettier` 3.8.4 -> 3.9.4 and reformats the two files affected by prettier's new union-type wrapping rule (`src/commands/register.ts`, `src/commands/unregister.ts`), so that Renovate PR #2446 can land cleanly against the default branch.

Renovate PR #2446 only bumped `package.json`/`pnpm-lock.yaml` without reformatting the affected files, which made `lint:prettier` fail in CI.

Closes the CI failure blocking #2446.